### PR TITLE
Upgrade action runtime to Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,19 @@ Thumbs.db
 # Build
 *.log
 
+# tsc intermediates in dist/ (only the ncc-bundled outputs should be tracked:
+# dist/index.js, dist/index.js.map, dist/licenses.txt, dist/sourcemap-register.js)
+dist/*.d.ts
+dist/*.d.ts.map
+dist/api.js
+dist/api.js.map
+dist/changes.js
+dist/changes.js.map
+dist/inputs.js
+dist/inputs.js.map
+dist/types.js
+dist/types.js.map
+
 # Environment
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ The action automatically retries with exponential backoff. If you see persistent
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 24+
 - npm
 
 ### Setup

--- a/action.yml
+++ b/action.yml
@@ -134,5 +134,5 @@ outputs:
     description: 'JSON array of work history entries'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
-        "@types/node": "^20.10.6",
+        "@types/node": "^24.0.0",
         "@vercel/ncc": "^0.38.4",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
@@ -1224,13 +1224,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -3921,9 +3921,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/sandgardenhq/doc-holiday-action#readme",
   "devDependencies": {
     "@types/jest": "^29.5.11",
-    "@types/node": "^20.10.6",
+    "@types/node": "^24.0.0",
     "@vercel/ncc": "^0.38.4",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
## Summary
- Bumps the GitHub Action runtime from `node20` to `node24` in `action.yml`, the CI workflow's `setup-node` to 24, and `@types/node` to `^24.0.0`.
- Cleans up `dist/` so only the ncc-bundled outputs are tracked and adds `.gitignore` rules to prevent future `tsc` intermediates from being committed.
- Updates the README development prerequisite from Node.js 20+ to 24+.

## Test plan
- [ ] CI (`test.yml`) passes on Node 24
- [ ] Smoke-test the published action in a downstream workflow to confirm the `node24` runtime resolves on GitHub-hosted runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)